### PR TITLE
Added workflow dispatch for easy releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,48 @@ on:
       - "v*"
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      wash_version:
+        description: "Version of wash, without the `v`, to release to chocolatey"
+        required: true
+        default: "0.18.0"
 
 jobs:
+  update-release:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Formula
+        env:
+          WASMCLOUD_URL: https://github.com/wasmCloud/wash/releases/download/v{{ inputs.wash_version }}/wash.exe
+        run: |
+          choco_template=$(cat ./template/chocolateyinstall.txt)
+          nuspec_template=$(cat ./template/wash.txt)
+
+          wasmcloud_url=$WASMCLOUD_URL
+          wasmcloud_sha=$(curl -sL $WASMCLOUD_URL | shasum -a 256 | cut -d ' ' -f 1 | tr '[:lower:]' '[:upper:]')
+          wasmcloud_version={{ inputs.wash_version }}
+
+          choco=$(echo "$choco_template" | sed "s|WASMCLOUD_URL|$wasmcloud_url|")
+          choco=$(echo "$choco" | sed "s|WASMCLOUD_SHA|$wasmcloud_sha|")
+
+          nuspec=$(echo "$nuspec_template" | sed "s|WASMCLOUD_VERSION|$wasmcloud_version|")
+
+          echo "$choco" > tools/chocolateyinstall.ps1
+          echo "$nuspec" > wash.nuspec
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: bump wash to v${{ inputs.wash_version }}
+          title: wash v${{ inputs.wash_version }}
+          body: This is the release of wash v${{ inputs.wash_version }}. Once tests pass properly, add the `pr-pull` label to this PR to release.
+          branch: release/v${{ inputs.wash_version }}
+          signoff: true
+
   check:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2

--- a/template/chocolateyinstall.txt
+++ b/template/chocolateyinstall.txt
@@ -1,0 +1,16 @@
+
+$ErrorActionPreference = 'Stop'; # stop on all errors
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$url64      = 'WASMCLOUD_URL'
+
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  fileFullPath  = "$toolsDir\wash.exe"
+  url64bit      = $url64
+
+  checksum64    = 'WASMCLOUD_SHA'
+  checksumType64= 'sha256'
+}
+
+Get-ChocolateyWebFile @packageArgs 

--- a/template/wash.txt
+++ b/template/wash.txt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>wash</id>
+  
+    <version>WASMCLOUD_VERSION</version>
+
+    <title>wash</title>
+    <authors>wasmCloud Maintainers</authors>
+    <projectUrl>https://wasmcloud.com</projectUrl>
+    <iconUrl>https://wasmcloud.com/img/wasmcloud_icon.png</iconUrl>
+    <licenseUrl>https://github.com/wasmCloud/wash/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/wasmcloud/wash</projectSourceUrl>
+    <packageSourceUrl>https://github.com/wasmCloud/chocolatey-wash</packageSourceUrl>
+    <docsUrl>https://wasmcloud.com</docsUrl>
+    <bugTrackerUrl>https://github.com/wasmCloud/wash/issues</bugTrackerUrl>
+    <tags>wash wasmCloud wasm</tags>
+    <summary>WAsmcloud SHell - the comprehensive command-line tool for wasmCloud development</summary>
+    <description>WAsmcloud SHell - the comprehensive command-line tool for wasmCloud development</description>
+    <releaseNotes>https://github.com/wasmCloud/wash/releases/tag/vWASMCLOUD_VERSION</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
## Feature or Problem
This PR adds a simple workflow_dispatch trigger to tests that will enable maintainers to trigger a release giving a new wash version, and then the PR will be created automatically for you. This just cuts out a few middle steps around computing the hash and all that.