### PR TITLE
Separated update from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,40 +7,8 @@ on:
       - "v*"
   pull_request:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      wash_version:
-        description: "Version of wash, without the `v`, to release to chocolatey"
-        required: true
-        default: "0.18.0"
-
 jobs:
-  update-release:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Prepare Formula
-        env:
-          WASMCLOUD_URL: https://github.com/wasmCloud/wash/releases/download/v${{ inputs.wash_version }}/wash.exe
-        run: |
-          wasmcloud_url=$WASMCLOUD_URL
-          wasmcloud_sha=$(curl -sL $WASMCLOUD_URL | shasum -a 256 | cut -d ' ' -f 1 | tr '[:lower:]' '[:upper:]')
-          wasmcloud_version=${{ inputs.wash_version }}
-
-          cat ./template/chocolateyinstall.txt | sed "s|WASMCLOUD_URL|$wasmcloud_url|" | sed "s|WASMCLOUD_SHA|$wasmcloud_sha|" > tools/chocolateyinstall.ps1
-          cat ./template/wash.txt | sed "s|WASMCLOUD_VERSION|$wasmcloud_version|" > wash.nuspec
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
-        with:
-          commit-message: bump wash to v${{ inputs.wash_version }}
-          title: wash v${{ inputs.wash_version }}
-          body: This is the release of wash v${{ inputs.wash_version }}. Once tests pass properly, simply merge and then cut a tag from `main` for this version.
-          branch: release/v${{ inputs.wash_version }}
-          signoff: true
-
   check:
-    if: github.event_name != 'workflow_dispatch'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,32 @@
+name: Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      wash_version:
+        description: "Version of wash, without the `v`, to release to chocolatey"
+        required: true
+        default: "0.18.0"
+jobs:
+  update-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Formula
+        env:
+          WASMCLOUD_URL: https://github.com/wasmCloud/wash/releases/download/v${{ inputs.wash_version }}/wash.exe
+        run: |
+          wasmcloud_url=$WASMCLOUD_URL
+          wasmcloud_sha=$(curl -sL $WASMCLOUD_URL | shasum -a 256 | cut -d ' ' -f 1 | tr '[:lower:]' '[:upper:]')
+          wasmcloud_version=${{ inputs.wash_version }}
+
+          cat ./template/chocolateyinstall.txt | sed "s|WASMCLOUD_URL|$wasmcloud_url|" | sed "s|WASMCLOUD_SHA|$wasmcloud_sha|" > tools/chocolateyinstall.ps1
+          cat ./template/wash.txt | sed "s|WASMCLOUD_VERSION|$wasmcloud_version|" > wash.nuspec
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: bump wash to v${{ inputs.wash_version }}
+          title: wash v${{ inputs.wash_version }}
+          body: This is the release of wash v${{ inputs.wash_version }}. Once tests pass properly, simply merge and then cut a tag from `main` for this version.
+          branch: release/v${{ inputs.wash_version }}
+          signoff: true


### PR DESCRIPTION
## Feature or Problem
This PR separates the workflow update from the release, because even though the templating worked out properly it still doesn't run the release check action since we already ran the action via workflow dispatch.

## Related Issues
Same fix as https://github.com/wasmCloud/homebrew-wasmcloud/pull/42

_should_ be the last iteration 😬 